### PR TITLE
extract constants/components, switch MDI to SVG icons

### DIFF
--- a/components/ChatForm.vue
+++ b/components/ChatForm.vue
@@ -5,7 +5,7 @@
       label="Message..."
       variant="outlined"
       :rules="rules"
-      append-inner-icon="mdi-send-circle-outline"
+      :append-inner-icon="mdiSendCircleOutline"
       @update:model-value="typing"
       @click:append-inner="send"
       @blur="resetValidation"
@@ -14,6 +14,7 @@
 </template>
 
 <script setup lang="ts">
+import { mdiSendCircleOutline } from '@mdi/js'
 import { useChatStore } from '~/stores/chat'
 
 const store = useChatStore()

--- a/components/TypingIndicator.vue
+++ b/components/TypingIndicator.vue
@@ -1,0 +1,29 @@
+<template>
+  <div v-if="users.length" class="typing" aria-live="polite">
+    <p
+      v-for="(user, index) in users"
+      :key="user.id ?? `typing-${index}`"
+      class="typing__user"
+    >
+      {{ user.name }} is typing...
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ChatUser } from '~/stores/chat'
+
+defineProps<{ users: ChatUser[] }>()
+</script>
+
+<style scoped>
+.typing {
+  position: absolute;
+  display: flex;
+  bottom: 50px;
+}
+
+.typing__user:not(:first-child) {
+  margin-left: 15px;
+}
+</style>

--- a/components/UsersList.vue
+++ b/components/UsersList.vue
@@ -1,0 +1,28 @@
+<template>
+  <v-list>
+    <v-list-subheader>Users in room</v-list-subheader>
+
+    <v-list-item
+      v-for="(user, index) in users"
+      :key="user.id ?? `user-${index}`"
+      :title="user.name"
+    >
+      <template #append>
+        <v-icon
+          :icon="mdiAccountCircleOutline"
+          :color="user.id === currentUserId ? 'primary' : 'grey'"
+        />
+      </template>
+    </v-list-item>
+  </v-list>
+</template>
+
+<script setup lang="ts">
+import { mdiAccountCircleOutline } from '@mdi/js'
+import type { ChatUser } from '~/stores/chat'
+
+defineProps<{
+  users: ChatUser[]
+  currentUserId?: string
+}>()
+</script>

--- a/layouts/chat.vue
+++ b/layouts/chat.vue
@@ -1,17 +1,7 @@
 <template>
   <v-app>
     <v-navigation-drawer v-model="drawer" :mobile-breakpoint="650" color="accent">
-      <v-list>
-        <v-list-subheader>Users in room</v-list-subheader>
-
-        <v-list-item v-for="({ name, id }, index) in users" :key="`user-${index}`" :title="name">
-          <template #append>
-            <v-icon :color="id === user?.id ? 'primary' : 'grey'">
-              mdi-account-circle-outline
-            </v-icon>
-          </template>
-        </v-list-item>
-      </v-list>
+      <UsersList :users="users" :current-user-id="user?.id" />
     </v-navigation-drawer>
 
     <v-app-bar color="#424242">
@@ -21,9 +11,7 @@
         <v-chip color="grey">{{ user?.room }}</v-chip>
       </v-toolbar-title>
       <v-spacer />
-      <v-btn icon class="mx-1" @click="exit">
-        <v-icon>mdi-exit-to-app</v-icon>
-      </v-btn>
+      <v-btn :icon="mdiExitToApp" class="mx-1" @click="exit" />
     </v-app-bar>
 
     <v-main>
@@ -35,21 +23,22 @@
 </template>
 
 <script setup lang="ts">
-import { storeToRefs } from 'pinia';
-import { useChatStore } from '~/stores/chat';
+import { mdiExitToApp } from '@mdi/js'
+import { storeToRefs } from 'pinia'
+import { useChatStore } from '~/stores/chat'
 
-const router = useRouter();
-const store = useChatStore();
-const { user, users } = storeToRefs(store);
+const router = useRouter()
+const store = useChatStore()
+const { user, users } = storeToRefs(store)
 
-const drawer = ref(true);
+const drawer = ref(true)
 
 onMounted(() => {
-  store.joinRoom();
-});
+  store.joinRoom()
+})
 
 function exit() {
-  store.leftRoom();
-  router.push('/?message=leftChat');
+  store.leftRoom()
+  router.push('/?message=leftChat')
 }
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,7 +2,9 @@ export default defineNuxtConfig({
   ssr: true,
   devtools: { enabled: true },
   modules: ['@pinia/nuxt', 'vuetify-nuxt-module', '@nuxt/eslint'],
-  css: ['@mdi/font/css/materialdesignicons.css'],
+  // No @mdi/font CSS — Vuetify uses the mdi-svg icon set and we import only
+  // the four path constants we actually render, via @mdi/js.
+  css: [],
   app: {
     head: {
       title: 'nuxt-chat-app',
@@ -20,7 +22,7 @@ export default defineNuxtConfig({
     },
     vuetifyOptions: {
       icons: {
-        defaultSet: 'mdi',
+        defaultSet: 'mdi-svg',
       },
       theme: {
         defaultTheme: 'dark',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@mdi/font": "^7.4.47",
+        "@mdi/js": "^7.4.47",
         "@pinia/nuxt": "^0.11.3",
         "pinia": "^3.0.4",
         "socket.io": "^4.8.1",
@@ -1986,10 +1986,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/@mdi/font": {
+    "node_modules/@mdi/js": {
       "version": "7.4.47",
-      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@mdi/font/-/font-7.4.47.tgz",
-      "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@mdi/js/-/js-7.4.47.tgz",
+      "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@mdi/font": "^7.4.47",
+    "@mdi/js": "^7.4.47",
     "@pinia/nuxt": "^0.11.3",
     "pinia": "^3.0.4",
     "socket.io": "^4.8.1",

--- a/pages/chat.vue
+++ b/pages/chat.vue
@@ -1,13 +1,14 @@
 <template>
   <div class="chat-wrapper">
     <div ref="chat" class="chat">
-      <Message v-for="(msg, index) in messages" :key="`message-${index}`" :message="msg" :owner="msg.id === user?.id" />
+      <Message
+        v-for="(msg, index) in messages"
+        :key="`message-${index}`"
+        :message="msg"
+        :owner="msg.id === user?.id"
+      />
     </div>
-    <div v-if="typingUsers.length" class="chat__typing">
-      <p v-for="(typingUser, index) in typingUsers" :key="`typingUser-${index}`" class="chat__typing-user">
-        {{ typingUser.name }} is typing...
-      </p>
-    </div>
+    <TypingIndicator :users="typingUsers" />
     <div class="chat__form">
       <ChatForm />
     </div>
@@ -15,40 +16,37 @@
 </template>
 
 <script setup lang="ts">
-import { storeToRefs } from 'pinia';
-import Message from '~/components/Message.vue';
-import ChatForm from '~/components/ChatForm.vue';
-import { useChatStore } from '~/stores/chat';
+import { storeToRefs } from 'pinia'
+import { CHAT_AUTOSCROLL_THRESHOLD_PX } from '~~/shared/constants'
+import { useChatStore } from '~/stores/chat'
 
-definePageMeta({ layout: 'chat', middleware: 'auth' });
+definePageMeta({ layout: 'chat', middleware: 'auth' })
 
-const store = useChatStore();
-const { user, messages } = storeToRefs(store);
-const typingUsers = computed(() => store.typingUsers);
+const store = useChatStore()
+const { user, messages } = storeToRefs(store)
+const typingUsers = computed(() => store.typingUsers)
 
-useHead({ title: () => `Room ${user?.value?.room ?? ''}` });
+useHead({ title: () => `Room ${user.value?.room ?? ''}` })
 
-const chat = ref<HTMLElement | null>(null);
-
-const NEAR_BOTTOM_PX = 80;
+const chat = ref<HTMLElement | null>(null)
 
 function isNearBottom(el: HTMLElement) {
-  return el.scrollHeight - (el.scrollTop + el.clientHeight) <= NEAR_BOTTOM_PX;
+  return el.scrollHeight - (el.scrollTop + el.clientHeight) <= CHAT_AUTOSCROLL_THRESHOLD_PX
 }
 
 watch(
   () => messages.value.length,
   () => {
-    const el = chat.value;
-    if (!el) return;
+    const el = chat.value
+    if (!el) return
     // Capture pre-render position so a new incoming message doesn't yank
     // a user who scrolled up to read history back to the bottom.
-    const shouldStick = isNearBottom(el);
+    const shouldStick = isNearBottom(el)
     nextTick(() => {
-      if (shouldStick && chat.value) chat.value.scrollTop = chat.value.scrollHeight;
-    });
+      if (shouldStick && chat.value) chat.value.scrollTop = chat.value.scrollHeight
+    })
   },
-);
+)
 </script>
 
 <style scoped>
@@ -76,15 +74,5 @@ watch(
   padding: 1rem;
   overflow-y: auto;
   color: #000;
-}
-
-.chat__typing {
-  position: absolute;
-  display: flex;
-  bottom: 50px;
-}
-
-.chat__typing-user:not(:first-child) {
-  margin-left: 15px;
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row no-gutters align="center" justify="center">
     <v-col cols="auto">
-      <v-snackbar v-model="snackbar" :timeout="3000" :color="snackbarColor" location="top">
+      <v-snackbar v-model="snackbar" :timeout="SNACKBAR_TIMEOUT_MS" :color="snackbarColor" location="top">
         {{ snackbarText }}
         <template #actions>
           <v-btn variant="text" @click="snackbar = false">Close</v-btn>
@@ -9,7 +9,6 @@
       </v-snackbar>
 
       <v-card min-width="290" color="#424242">
-
         <v-card-title>
           <h2>Login</h2>
         </v-card-title>
@@ -17,14 +16,14 @@
           <v-form ref="form" v-model="isValid" @submit.prevent="submit">
             <v-text-field
               v-model="user.name"
-              :counter="16"
+              :counter="MAX_NAME_LEN"
               :rules="nameRules"
               label="Name"
               required
             />
             <v-text-field
               v-model="user.room"
-              :counter="16"
+              :counter="MAX_ROOM_LEN"
               :rules="roomRules"
               label="Enter the room"
               required
@@ -47,6 +46,7 @@
 
 <script setup lang="ts">
 import messageDict from '~/lib/messageDict'
+import { MAX_NAME_LEN, MAX_ROOM_LEN, SNACKBAR_TIMEOUT_MS } from '~~/shared/constants'
 import { useChatStore } from '~/stores/chat'
 
 definePageMeta({ layout: 'login' })
@@ -66,11 +66,11 @@ const user = reactive({
 
 const nameRules = [
   (v: string) => !!v || 'Name is required',
-  (v: string) => (v && v.length <= 16) || 'Name must be less than 16 characters',
+  (v: string) => (v && v.length <= MAX_NAME_LEN) || `Name must be ${MAX_NAME_LEN} characters or fewer`,
 ]
 const roomRules = [
   (v: string) => !!v || 'Enter the room',
-  (v: string) => (v && v.length <= 16) || 'Room must be less than 16 characters',
+  (v: string) => (v && v.length <= MAX_ROOM_LEN) || `Room must be ${MAX_ROOM_LEN} characters or fewer`,
 ]
 
 const initialMessage = (() => {

--- a/plugins/socket.client.ts
+++ b/plugins/socket.client.ts
@@ -1,4 +1,5 @@
 import { io, type Socket } from 'socket.io-client'
+import { SOCKET_EVENTS } from '~~/shared/constants'
 import { useChatStore } from '~/stores/chat'
 
 export default defineNuxtPlugin(() => {
@@ -11,8 +12,8 @@ export default defineNuxtPlugin(() => {
 
   const store = useChatStore()
 
-  socket.on('newMessage', (msg) => store.addMessage(msg))
-  socket.on('updateUsers', (users) => store.setUsers(users))
+  socket.on(SOCKET_EVENTS.NEW_MESSAGE, msg => store.addMessage(msg))
+  socket.on(SOCKET_EVENTS.UPDATE_USERS, users => store.setUsers(users))
   socket.io.on('reconnect', () => store.reconnect())
 
   return {

--- a/server/plugins/socket.ts
+++ b/server/plugins/socket.ts
@@ -1,13 +1,16 @@
 import type { Server as HttpServer } from 'node:http'
 import { Server as IOServer, type Socket } from 'socket.io'
+import {
+  MAX_MSG_LEN,
+  MAX_NAME_LEN,
+  MAX_ROOM_LEN,
+  SOCKET_EVENTS,
+  SYSTEM_AUTHOR,
+} from '../../shared/constants'
 import { Message } from '../utils/Message'
 import { usersDB } from '../utils/users'
 
 let io: IOServer | null = null
-
-const MAX_NAME_LEN = 16
-const MAX_ROOM_LEN = 16
-const MAX_MSG_LEN = 1000
 
 function isCleanString(v: unknown, maxLen: number): v is string {
   return typeof v === 'string' && v.length > 0 && v.length <= maxLen
@@ -15,7 +18,7 @@ function isCleanString(v: unknown, maxLen: number): v is string {
 
 function attachHandlers(server: IOServer) {
   server.on('connection', (socket: Socket) => {
-    socket.on('createUser', (user: unknown, ack) => {
+    socket.on(SOCKET_EVENTS.CREATE_USER, (user: unknown, ack) => {
       const u = user as { name?: unknown; room?: unknown; typingStatus?: unknown } | undefined
       if (!isCleanString(u?.name, MAX_NAME_LEN) || !isCleanString(u?.room, MAX_ROOM_LEN)) return
       usersDB.addUser({
@@ -27,39 +30,42 @@ function attachHandlers(server: IOServer) {
       if (typeof ack === 'function') ack({ id: socket.id })
     })
 
-    socket.on('joinRoom', (_payload: unknown) => {
+    socket.on(SOCKET_EVENTS.JOIN_ROOM, (_payload: unknown) => {
       // Source of truth is server-side state, not the client-supplied payload.
       const user = usersDB.getUser(socket.id)
       if (!user) return
       const { name, room } = user
       socket.join(room)
-      server.to(room).emit('updateUsers', usersDB.getUsersByRoom(room))
-      socket.emit('newMessage', new Message('admin', `Hello, ${name}`))
+      server.to(room).emit(SOCKET_EVENTS.UPDATE_USERS, usersDB.getUsersByRoom(room))
+      socket.emit(SOCKET_EVENTS.NEW_MESSAGE, new Message(SYSTEM_AUTHOR, `Hello, ${name}`))
       socket.broadcast
         .to(room)
-        .emit('newMessage', new Message('admin', `User ${name} connected to chat`))
+        .emit(SOCKET_EVENTS.NEW_MESSAGE, new Message(SYSTEM_AUTHOR, `User ${name} connected to chat`))
     })
 
-    socket.on('createMessage', (payload: unknown) => {
+    socket.on(SOCKET_EVENTS.CREATE_MESSAGE, (payload: unknown) => {
       const p = payload as { msg?: unknown } | undefined
       if (!isCleanString(p?.msg, MAX_MSG_LEN)) return
       // Ignore any client-supplied id; only trust socket.id.
       const user = usersDB.getUser(socket.id)
       if (!user) return
-      server.to(user.room).emit('newMessage', new Message(user.name, p.msg as string, socket.id))
+      server.to(user.room).emit(
+        SOCKET_EVENTS.NEW_MESSAGE,
+        new Message(user.name, p.msg as string, socket.id),
+      )
     })
 
-    socket.on('setTypingStatus', (payload: unknown) => {
+    socket.on(SOCKET_EVENTS.SET_TYPING_STATUS, (payload: unknown) => {
       const p = payload as { typingStatus?: unknown } | undefined
       if (typeof p?.typingStatus !== 'boolean') return
       // Ignore any client-supplied room/id; only trust server state.
       const user = usersDB.getUser(socket.id)
       if (!user) return
       usersDB.setTypingStatus(socket.id, p.typingStatus)
-      server.to(user.room).emit('updateUsers', usersDB.getUsersByRoom(user.room))
+      server.to(user.room).emit(SOCKET_EVENTS.UPDATE_USERS, usersDB.getUsersByRoom(user.room))
     })
 
-    const exitEvents = ['leftChat', 'disconnect'] as const
+    const exitEvents = [SOCKET_EVENTS.LEFT_CHAT, 'disconnect'] as const
     exitEvents.forEach((event) => {
       socket.on(event, () => {
         const user = usersDB.getUser(socket.id)
@@ -67,10 +73,10 @@ function attachHandlers(server: IOServer) {
         const { room, name } = user
         usersDB.removeUser(socket.id)
         socket.leave(room)
-        server.to(room).emit('updateUsers', usersDB.getUsersByRoom(room))
+        server.to(room).emit(SOCKET_EVENTS.UPDATE_USERS, usersDB.getUsersByRoom(room))
         server
           .to(room)
-          .emit('newMessage', new Message('admin', `User ${name} left chat`))
+          .emit(SOCKET_EVENTS.NEW_MESSAGE, new Message(SYSTEM_AUTHOR, `User ${name} left chat`))
       })
     })
   })

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,0 +1,25 @@
+// Constants shared by client and server. Single source of truth so a typo
+// or length change on one side can't silently diverge from the other.
+
+export const MAX_NAME_LEN = 16
+export const MAX_ROOM_LEN = 16
+export const MAX_MSG_LEN = 1000
+
+// UI tuning
+export const SNACKBAR_TIMEOUT_MS = 3000
+export const CREATE_USER_TIMEOUT_MS = 10_000
+export const CHAT_AUTOSCROLL_THRESHOLD_PX = 80
+
+// Socket.io event names. Use these everywhere instead of bare strings.
+export const SOCKET_EVENTS = {
+  CREATE_USER: 'createUser',
+  JOIN_ROOM: 'joinRoom',
+  CREATE_MESSAGE: 'createMessage',
+  SET_TYPING_STATUS: 'setTypingStatus',
+  LEFT_CHAT: 'leftChat',
+  NEW_MESSAGE: 'newMessage',
+  UPDATE_USERS: 'updateUsers',
+} as const
+
+// The author of admin/system messages ("User X joined", etc.).
+export const SYSTEM_AUTHOR = 'admin'

--- a/stores/chat.ts
+++ b/stores/chat.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import type { Socket } from 'socket.io-client'
+import { CREATE_USER_TIMEOUT_MS, SOCKET_EVENTS } from '~~/shared/constants'
 
 export interface ChatUser {
   id: string
@@ -34,7 +35,7 @@ export const useChatStore = defineStore('chat', {
 
   getters: {
     typingUsers(state) {
-      return state.users.filter(u => u.typingStatus && state.user?.id !== u.id)
+      return state.users.filter(user => user.typingStatus && state.user?.id !== user.id)
     },
     typingStatus(state): boolean {
       return Boolean(state.user?.typingStatus)
@@ -61,28 +62,30 @@ export const useChatStore = defineStore('chat', {
     },
 
     async createUser(payload: CreateUserPayload) {
-      const ack = (await getSocket().timeout(10_000).emitWithAck('createUser', payload)) as { id: string }
+      const ack = (await getSocket()
+        .timeout(CREATE_USER_TIMEOUT_MS)
+        .emitWithAck(SOCKET_EVENTS.CREATE_USER, payload)) as { id: string }
       this.user = { ...payload, id: ack.id }
     },
 
     joinRoom() {
       if (!this.user) return
-      getSocket().emit('joinRoom', { name: this.user.name, room: this.user.room })
+      getSocket().emit(SOCKET_EVENTS.JOIN_ROOM, { name: this.user.name, room: this.user.room })
     },
 
     createMessage(msg: string) {
       if (!this.user) return
-      getSocket().emit('createMessage', { msg })
+      getSocket().emit(SOCKET_EVENTS.CREATE_MESSAGE, { msg })
     },
 
     setTypingStatus(status: boolean) {
       this.setTypingStatusLocal(status)
       if (!this.user) return
-      getSocket().emit('setTypingStatus', { typingStatus: status })
+      getSocket().emit(SOCKET_EVENTS.SET_TYPING_STATUS, { typingStatus: status })
     },
 
     leftRoom() {
-      getSocket().emit('leftChat')
+      getSocket().emit(SOCKET_EVENTS.LEFT_CHAT)
       this.clearData()
     },
 


### PR DESCRIPTION
Performance: dropped @mdi/font (full ~7k-icon CSS) in favour of @mdi/js + Vuetify's mdi-svg icon set, importing only the 4 path constants we actually render. Entry CSS shrinks from 524 KB to 208 KB and the install no longer pulls 11 MB of webfont files — should also make Render's 512 MB free-tier install fit.

Extractions:
- shared/constants.ts as the single source of truth for socket event names, length caps (name/room/message), UI timings, and the system-message author. Server, store, plugin, and login rules all import from here instead of repeating magic values.
- components/UsersList.vue (drawer list) and TypingIndicator.vue (with aria-live="polite") pulled out of layouts/chat.vue and pages/chat.vue, leaving each parent shorter and more obvious.
- pages/chat.vue drops the explicit Message/ChatForm imports; Nuxt's components/ auto-import handles them.